### PR TITLE
Use `pragma solidity ^0.8.16` in IncreAccessControl

### DIFF
--- a/contracts/utils/IncreAccessControl.sol
+++ b/contracts/utils/IncreAccessControl.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity 0.8.16;
+pragma solidity ^0.8.16;
 
 // contracts
 import {AccessControl} from "../../lib/openzeppelin-contracts/contracts/access/AccessControl.sol";


### PR DESCRIPTION
For compatibility with Era contracts which require `0.8.20` (specifically IAccount.sol, used by WIP IncrementLimitOrderModule), as well as Clave contracts which require `^0.8.17`, allow inheriting IncreAccessControl.sol in contracts requiring solidity versions > `0.8.16`

![Line Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/increment-bot/bc4d7f80aa422d6d020a11baf639db03/raw/increment-protocol-line-coverage__pull_##.json)
![Statement Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/increment-bot/bc4d7f80aa422d6d020a11baf639db03/raw/increment-protocol-statement-coverage__pull_##.json)
![Branch Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/increment-bot/bc4d7f80aa422d6d020a11baf639db03/raw/increment-protocol-branch-coverage__pull_##.json)
![Function Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/increment-bot/bc4d7f80aa422d6d020a11baf639db03/raw/increment-protocol-function-coverage__pull_723.json)

**Notes for reviewer:**

- See this [failing Github action](https://github.com/Increment-Finance/peripheral-contracts/actions/runs/8728606057/job/23948778119?pr=67#step:5:13) in the peripheral contracts repo
